### PR TITLE
lightdm: Remove old config for theming

### DIFF
--- a/lightdm/10_budgie.conf
+++ b/lightdm/10_budgie.conf
@@ -1,4 +1,0 @@
-[greeter]
-background=/usr/share/backgrounds/budgie/lake-sherburne.jpg
-theme-name=Materia-dark
-icon-theme-name=Papirus

--- a/lightdm/meson.build
+++ b/lightdm/meson.build
@@ -1,12 +1,6 @@
-lightdm_gtk_dir = join_paths(path_datadir, 'lightdm', 'lightdm-gtk-greeter.conf.d')
 lightdm_dir = join_paths(path_datadir, 'lightdm', 'lightdm.conf.d')
 
 install_data(
     'budgie_config.conf',
     install_dir: lightdm_dir,
-)
-
-install_data(
-    '10_budgie.conf',
-    install_dir: lightdm_gtk_dir,
 )


### PR DESCRIPTION
This doesn't do anything since moving to slick-greeter. Slick-greeter gets overridden by x.dm.slick-greeter gschema overrides.