### PR TITLE
mimeapps: Add more firefox associations

### DIFF
--- a/mimeapps.list
+++ b/mimeapps.list
@@ -45,10 +45,16 @@ multipart/x-zip=org.gnome.FileRoller.desktop
 # Browser (Firefox)
 application/rdf+xml=firefox.desktop;
 application/rss+xml=firefox.desktop;
+application/x-extension-htm=firefox.desktop;
+application/x-extension-html=firefox.desktop;
+application/x-extension-shtml=firefox.desktop;
+application/x-extension-xht=firefox.desktop;
+application/x-extension-xhtml=firefox.desktop;
 application/xhtml+xml=firefox.desktop;
-text/html=firefox.desktop;
-x-scheme-handler/http=firefox.desktop;
-x-scheme-handler/https=firefox.desktop;
+text/html=firefox.desktop
+x-scheme-handler/chrome=firefox.desktop
+x-scheme-handler/http=firefox.desktop
+x-scheme-handler/https=firefox.desktop
 
 # Email (Thunderbird)
 application/mbox=net.thunderbird.Thunderbird.desktop


### PR DESCRIPTION
Due to some path fuckery Firefox thought it wasn't the default browser. When I selected "make default", it updated it's own mimetype associations. From that list I was able to get some additional ones that we should have our defaults cover.